### PR TITLE
changed next() to __next__()

### DIFF
--- a/records.py
+++ b/records.py
@@ -36,6 +36,9 @@ class ResultSet(object):
             yield row
         self._completed = True
 
+    def next(self):
+        return self.__next__()
+
     def __next__(self):
         try:
             return next(self._rows)

--- a/records.py
+++ b/records.py
@@ -36,9 +36,9 @@ class ResultSet(object):
             yield row
         self._completed = True
 
-    def next(self):
+    def __next__(self):
         try:
-            return self._rows.next()
+            return next(self._rows)
         except StopIteration:
             raise StopIteration("ResultSet contains no more rows.")
 


### PR DESCRIPTION
In Python 3 the .next() method was replaced with the next() function which calls the __next__ method.
The built-in next() function also works in Python 2.6 or greater