### PR TITLE
Fix a typo in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ Excellent for sharing data with friends, or generating reports.
 
   .. code:: python
 
-      >>> print rows.export('yaml')
+      >>> print rows.export('json')
       [{"username": "model-t", "active": true, "name": "Henry Ford", "user_email": "model-t@gmail.com", "timezone": "2016-02-06 22:28:23.894202"}, ...]
 
 - Microsoft Excel (xls, xlsx)


### PR DESCRIPTION
It said `yaml` instead of `json` in the JSON example and it bugged me.