### PR TITLE
Fix race condition in ResultSet.__iter__

### DIFF
--- a/records.py
+++ b/records.py
@@ -112,17 +112,14 @@ class ResultSet(object):
         return r
 
     def __iter__(self):
-        """Starts by returning the cached items and then consumes the
-        generator in case it is not fully consumed.
-        """
-        if self._all_rows:
-            for row in self._all_rows:
-                yield row
-        try:
-            while True:
-                yield self.__next__()
-        except StopIteration:
-            pass
+        """Iterate over all rows, consuming the underlying generator only when necessary."""
+        i = 0
+        while True:
+            # Other code may have iterated between yields, so always check the cache.
+            if i < len(self._all_rows): yield self._all_rows[i]
+            else: yield next(self)  # Throws StopIteration when done.
+            i += 1
+
 
     def next(self):
         return self.__next__()


### PR DESCRIPTION
Fixes #13, hopefully for good this time.

More generally, I think the subtleties of the `_all_rows` cache may keep leading to sneaky bugs, so it might be worth wrapping the `_rows` generator in a "lazy list" class—supporting both iteration and indexing with caching. You could abstract that out from what's already there, or use something like https://github.com/ryanhaining/lazylist (I haven't used it, but it looks to be exactly what I'm talking about).