### PR TITLE
Allow calling `as_dict` on entire RecordCollection

### DIFF
--- a/records.py
+++ b/records.py
@@ -189,6 +189,10 @@ class RecordCollection(object):
 
         return rows
 
+    def as_dict(self, ordered=False):
+        return self.all(as_dict=not(ordered), as_ordereddict=ordered)
+
+
 class Database(object):
     """A Database connection."""
 


### PR DESCRIPTION
I think it makes sense to have similar Apis for both the `Record` and `RecordCollection`. Having to use a different method to get a dictionary representation is a little unintuitive.

Brings back the Api described in the Readme.

This method simply calls the `all` method using the `kwargs`. Defaults to unordered dict.