### PR TITLE
Retrieve attributes using super instead of hard-coding

### DIFF
--- a/records.py
+++ b/records.py
@@ -53,16 +53,7 @@ class Record(object):
             raise AttributeError(e)
 
     def __dir__(self):
-        standard = [
-            # Would love to do this programatically, but couldn't figure out how.
-            '__class__', '__ddir__', '__delattr__', '__doc__', '__format__',
-            '__getattr__', '__getattribute__', '__getitem__', '__hash__',
-            '__init__', '__module__', '__new__', '__reduce__', '__reduce_ex__',
-            '__repr__', '__setattr__', '__sizeof__', '__slots__', '__str__',
-            '__subclasshook__', '_keys', '_values', 'as_dict', 'dataset',
-            'export', 'get', 'keys', 'values'
-        ]
-
+        standard = super(Record, self).__dir__()
         # Merge standard attrs with generated ones (from column names).
         return sorted(standard + [str(k) for k in self.keys()])
 

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -5,8 +5,10 @@ import records
 
 IdRecord = namedtuple('IdRecord', 'id')
 
+
 def check_id(i, row):
     assert row.id == i
+
 
 class TestRecordCollection:
     def test_iter(self):
@@ -45,3 +47,15 @@ class TestRecordCollection:
         for i, row in enumerate(rows):
             check_id(i, row)
         assert len(rows) == 10
+
+
+class TestRecord:
+
+    def test_record_dir(self):
+        keys, values = ['id', 'name', 'email'], [1, '', '']
+        record = records.Record(keys, values)
+        _dir = dir(record)
+        for key in keys:
+            assert key in _dir
+        for key in dir(object):
+            assert key in _dir


### PR DESCRIPTION
You left a comment wanting to do it programmatically, and I found a way!

``` python
>>> from records import Record
>>> record = Record(['id','name'],[2,'Tobin'])
>>> dir(record)
['__class__', '__delattr__', '__dir__', '__doc__', '__eq__', '__format__',
 '__ge__', '__getattr__', '__getattribute__', '__getitem__', '__gt__',
 '__hash__', '__init__', '__le__', '__lt__', '__module__', '__ne__',
 '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__',
 '__sizeof__', '__slots__', '__str__', '__subclasshook__', '_keys', '_values',
 'as_dict', 'dataset', 'export', 'get', 'id', 'keys', 'name', 'values']
```
