### PR TITLE
Add support for transactions

### DIFF
--- a/records.py
+++ b/records.py
@@ -270,6 +270,11 @@ class Database(object):
         # Defer processing to self.query method.
         return self.query(query=query, fetchall=fetchall, **params)
 
+    def transaction(self):
+        """Returns a transaction object. Call ``commit`` or ``rollback``
+        on the returned object as appropriate."""
+        return self.db.begin()
+
 def _reduce_datetimes(row):
     """Receives a row, converts datetimes to strings."""
 
@@ -279,7 +284,6 @@ def _reduce_datetimes(row):
         if hasattr(row[i], 'isoformat'):
             row[i] = row[i].isoformat()
     return tuple(row)
-
 
 def cli():
     cli_docs ="""Records: SQL for Humans™

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,0 +1,31 @@
+import pytest
+
+import records
+
+db = records.Database('sqlite:///:memory:')
+
+db.query('CREATE TABLE foo (a integer)')
+
+def test_failing_transaction():
+    tx = db.transaction()
+    try:
+        db.query('INSERT INTO foo VALUES (42)')
+        db.query('INSERT INTO foo VALUES (43)')
+        raise ValueError()
+        tx.commit()
+        db.query('INSERT INTO foo VALUES (44)')
+    except:
+        tx.rollback()
+    finally:
+        assert db.query('SELECT count(*) AS n FROM foo')[0].n == 0
+
+def test_passing_transaction():
+    tx = db.transaction()
+    try:
+        db.query('INSERT INTO foo VALUES (42)')
+        db.query('INSERT INTO foo VALUES (43)')
+        tx.commit()
+    except:
+        tx.rollback()
+    finally:
+        assert db.query('SELECT count(*) AS n FROM foo')[0].n == 2

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,5 +1,3 @@
-import pytest
-
 import records
 
 db = records.Database('sqlite:///:memory:')


### PR DESCRIPTION
This is just a convenience for supporting transactions using SQLAlchemy's support thereof.

One could always just call this:

```
db = records.Database()
tx = db.db.begin()
db.query(...)
db.query(...)
tx.commit()
```

but that `db.db` looks funny to me.  With this, it becomes:

```
db = records.Database()
tx = db.transaction()
try:
  db.query(...)
  db.query(...)
  tx.commit()
except:
  tx.rollback()
```
