### PR TITLE
Pass Database.__init__ kwargs to create_engine

### DIFF
--- a/records.py
+++ b/records.py
@@ -196,7 +196,7 @@ class RecordCollection(object):
 class Database(object):
     """A Database connection."""
 
-    def __init__(self, db_url=None):
+    def __init__(self, db_url=None, **kwargs):
         # If no db_url was provided, fallback to $DATABASE_URL.
         self.db_url = db_url or DATABASE_URL
 
@@ -204,7 +204,7 @@ class Database(object):
             raise ValueError('You must provide a db_url.')
 
         # Connect to the database.
-        self.db = create_engine(self.db_url).connect()
+        self.db = create_engine(self.db_url, **kwargs).connect()
         self.open = True
 
     def close(self):


### PR DESCRIPTION
This change allows setting the behaviour of the SQLAlchemy engine (for example setting check_same_thread to False for sqlite3 databases).