### PR TITLE
Human readable transactions using `with`

### DIFF
--- a/records.py
+++ b/records.py
@@ -286,7 +286,7 @@ class TransactionContext():
             self.transaction.commit()
         else:
             self.transaction.rollback()
-
+        return True
 
 def _reduce_datetimes(row):
     """Receives a row, converts datetimes to strings."""

--- a/records.py
+++ b/records.py
@@ -270,6 +270,24 @@ class Database(object):
         # Defer processing to self.query method.
         return self.query(query=query, fetchall=fetchall, **params)
 
+    def transaction(self):
+        return TransactionContext(self.db)
+
+class TransactionContext():
+    def __init__(self, db):
+        self.db = db
+
+    def __enter__(self):
+        self.transaction = self.db.begin()
+        return self.transaction
+
+    def __exit__(self, exc_type, exc_value, tb):
+        if exc_type == None:
+            self.transaction.commit()
+        else:
+            self.transaction.rollback()
+
+
 def _reduce_datetimes(row):
     """Receives a row, converts datetimes to strings."""
 

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -7,14 +7,11 @@ db.query('CREATE TABLE foo (a integer)')
 
 
 def test_failing_transaction():
-    try:
-        with db.transaction():
-            db.query('INSERT INTO foo VALUES (42)')
-            db.query('INSERT INTO foo VALUES (43)')
-            raise ValueError()
-            db.query('INSERT INTO foo VALUES (44)')
-    except ValueError:
-        pass
+    with db.transaction():
+        db.query('INSERT INTO foo VALUES (42)')
+        db.query('INSERT INTO foo VALUES (43)')
+        raise ValueError()
+        db.query('INSERT INTO foo VALUES (44)')
     assert db.query('SELECT count(*) AS n FROM foo')[0].n == 0
 
 def test_passing_transaction():

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -2,6 +2,27 @@ from collections import namedtuple
 
 import records
 
+db = records.Database('sqlite:///:memory:')
+db.query('CREATE TABLE foo (a integer)')
+
+
+def test_failing_transaction():
+    try:
+        with db.transaction():
+            db.query('INSERT INTO foo VALUES (42)')
+            db.query('INSERT INTO foo VALUES (43)')
+            raise ValueError()
+            db.query('INSERT INTO foo VALUES (44)')
+    except ValueError:
+        pass
+    assert db.query('SELECT count(*) AS n FROM foo')[0].n == 0
+
+def test_passing_transaction():
+    with db.transaction():
+        db.query('INSERT INTO foo VALUES (42)')
+        db.query('INSERT INTO foo VALUES (43)')
+    assert db.query('SELECT count(*) AS n FROM foo')[0].n == 2
+
 
 IdRecord = namedtuple('IdRecord', 'id')
 


### PR DESCRIPTION
Inspired by #58 
I see this syntax for transactions much more readable

``` python
with db.transaction():
    db.query('INSERT INTO foo VALUES (42)')
    db.query('INSERT INTO foo VALUES (43)')
```

If any exception was raised transaction will be rollbacked, otherwise -- automatically committed.
All exception which occurred inside of transaction block are suppressed.
