### PR TITLE
CLI function docstring requires format should be optional

### DIFF
--- a/records.py
+++ b/records.py
@@ -324,7 +324,7 @@ def cli():
 A Kenneth Reitz project.
 
 Usage:
-  records <query> <format> [<params>...] [--url=<url>]
+  records <query> [<format>] [<params>...] [--url=<url>]
   records (-h | --help)
 
 Options:


### PR DESCRIPTION
Changed line 327 to have format as optional parameter as lines 385-389 imply should be the case.
Old: records <query> <format> [<params>...] [--url=<url>]
New: records <query> [<format>] [<params>...] [--url=<url>]