### PR TITLE
Reuse engine for get_table_names, use inspection instead of metadata reflection

### DIFF
--- a/records.py
+++ b/records.py
@@ -6,7 +6,7 @@ from inspect import isclass
 
 import tablib
 from docopt import docopt
-from sqlalchemy import MetaData, create_engine, inspect, text
+from sqlalchemy import create_engine, inspect, text
 
 DATABASE_URL = os.environ.get('DATABASE_URL')
 

--- a/records.py
+++ b/records.py
@@ -6,8 +6,7 @@ from inspect import isclass
 
 import tablib
 from docopt import docopt
-from sqlalchemy import text, create_engine
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import MetaData, create_engine, inspect, text
 
 DATABASE_URL = os.environ.get('DATABASE_URL')
 
@@ -237,8 +236,10 @@ class Database(object):
         if not self.db_url:
             raise ValueError('You must provide a db_url.')
 
+        self._engine = create_engine(self.db_url, **kwargs)
+
         # Connect to the database.
-        self.db = create_engine(self.db_url, **kwargs).connect()
+        self.db = self._engine.connect()
         self.open = True
 
     def close(self):
@@ -259,11 +260,7 @@ class Database(object):
         """Returns a list of table names for the connected database."""
 
         # Setup SQLAlchemy for Database inspection.
-        metadata = declarative_base().metadata
-        metadata.reflect(create_engine(self.db_url))
-
-        # Serve the table names.
-        return metadata.tables.keys()
+        return inspect(self._engine).get_table_names()
 
     def query(self, query, fetchall=False, **params):
         """Executes the given SQL query against the Database. Parameters


### PR DESCRIPTION
Fixes `get_table_names` implementation, which I explain in #74 and restate here:

The following steps are executed every time, making the function much more expensive than it needs to be:
1. a new engine is created rather than using the existing one to check out a connection
2. a declarative base is created just to use its metadata, which is better created using `sqlalchemy.MetaData()`
3. The whole database schema is reflected just to get the table names.