### PR TITLE
Disable SQLAlchemy connection pooling

### DIFF
--- a/records.py
+++ b/records.py
@@ -7,6 +7,7 @@ from inspect import isclass
 import tablib
 from docopt import docopt
 from sqlalchemy import text, create_engine
+from sqlalchemy.pool import NullPool
 from sqlalchemy.ext.declarative import declarative_base
 
 DATABASE_URL = os.environ.get('DATABASE_URL')
@@ -233,6 +234,10 @@ class Database(object):
     def __init__(self, db_url=None, **kwargs):
         # If no db_url was provided, fallback to $DATABASE_URL.
         self.db_url = db_url or DATABASE_URL
+
+        # Turn off SQLAlchemy's connection pooling by default, otherwise we'll
+        # keep a connection open even after Database.close() is called.
+        kwargs.setdefault('poolclass', NullPool)
 
         if not self.db_url:
             raise ValueError('You must provide a db_url.')


### PR DESCRIPTION
The `Database` class provides no way to use it, and the current
implementation means that a connection is held by the pool even after
`db.close()`.

See also #67.