### PR TITLE
Fixed accidental StopIteration bubbling in RecordCollection.__iter__

### DIFF
--- a/records.py
+++ b/records.py
@@ -118,7 +118,11 @@ class RecordCollection(object):
                 yield self[i]
             else:
                 # Throws StopIteration when done.
-                yield next(self)
+                # Prevent StopIteration bubbling from generator, following https://www.python.org/dev/peps/pep-0479/
+                try:
+                    yield next(self)
+                except StopIteration:
+                    return
             i += 1
 
 


### PR DESCRIPTION
In new python versions old code raises: `DeprecationWarning: generator 'RecordCollection.__iter__' raised StopIteration`

This patch fixes it :)

For more info check this PEP: https://www.python.org/dev/peps/pep-0479/