### PR TITLE
Fix indentation error

### DIFF
--- a/records.py
+++ b/records.py
@@ -288,9 +288,9 @@ class Database(object):
 
     def bulk_query(self, query, *multiparams):
         """Bulk insert or update."""
-        
+
         self.db.execute(text(query), *multiparams)
-        
+
     def query_file(self, path, fetchall=False, **params):
         """Like Database.query, but takes a filename to load a query from."""
 
@@ -308,10 +308,10 @@ class Database(object):
 
         # Defer processing to self.query method.
         return self.query(query=query, fetchall=fetchall, **params)
-    
-     def bulk_query_file(self, path, *multiparams):
+
+    def bulk_query_file(self, path, *multiparams):
         """Like Database.bulk_query, but takes a filename to load a query from."""
-        
+
          # If path doesn't exists
         if not os.path.exists(path):
             raise IOError("File '{}'' not found!".format(path))
@@ -323,7 +323,7 @@ class Database(object):
         # Read the given .sql file into memory.
         with open(path) as f:
             query = f.read()
-        
+
         self.db.execute(text(query), *multiparams)
 
     def transaction(self):
@@ -413,7 +413,3 @@ Notes:
 # Run the CLI when executed directly.
 if __name__ == '__main__':
     cli()
-
-
-
-


### PR DESCRIPTION
This PR fixes an indentation error on line 312, preventing the module from being imported.

```
import records
Traceback (most recent call last):

  File "/usr/local/lib/python3.6/site-packages/IPython/core/interactiveshell.py", line 2862, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)

  File "<ipython-input-2-2fdfd4b889dd>", line 1, in <module>
    import records

  File "/usr/local/lib/python3.6/site-packages/records.py", line 312
    def bulk_query_file(self, path, *multiparams):
                                                  ^
IndentationError: unindent does not match any outer indentation level
```
