### PR TITLE
Make pandas support optional, as it is with tablib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if sys.argv[-1] == 'publish':
     os.system('python setup.py bdist_wheel upload --universal')
     sys.exit()
 
-requires = ['SQLAlchemy', 'tablib[pandas]', 'docopt']
+requires = ['SQLAlchemy', 'tablib', 'docopt']
 version = '0.5.1'
 
 
@@ -35,6 +35,9 @@ setup(
         'console_scripts': ['records=records:cli'],
     },
     install_requires=requires,
+    extras_require={
+        'pandas': ['tablib[pandas]'],
+    },
     license='ISC',
     zip_safe=False,
     classifiers=(


### PR DESCRIPTION
For the same reasons as with kennethreitz/tablib#307, it's preferable
that pandas support not be included by default.

* pandas wheels weigh in at 130M which counts for a lot when working
with environments like AWS Lambda which are limited to 256M.
* Some people can't use wheels and having to compile pandas
siginificantly slows down their build proceses and CI pipelines.

Thanks for these awesome libraries @kennethreitz!