### PR TITLE
Raise an error if selecting column that exists more than once

### DIFF
--- a/records.py
+++ b/records.py
@@ -52,6 +52,8 @@ class Record(object):
         # Support for string-based lookup.
         if key in self.keys():
             i = self.keys().index(key)
+            if self.keys().count(key) > 1:
+                raise KeyError("Record contains multiple '{}' fields.".format(key))
             return self.values()[i]
 
         raise KeyError("Record contains no '{}' field.".format(key))

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -97,3 +97,9 @@ class TestRecord:
             assert key in _dir
         for key in dir(object):
             assert key in _dir
+
+    def test_record_duplicate_column(self):
+        keys, values = ['id', 'name', 'email', 'email'], [1, '', '', '']
+        record = records.Record(keys, values)
+        with raises(KeyError):
+            record['email']


### PR DESCRIPTION
This caused a pretty major bug for us

also, closes #108