### PR TITLE
Properly handle SQLAlchemy connection pools

### DIFF
--- a/records.py
+++ b/records.py
@@ -7,7 +7,7 @@ from inspect import isclass
 
 import tablib
 from docopt import docopt
-from sqlalchemy import create_engine, inspect, text
+from sqlalchemy import create_engine, exc, inspect, text
 
 DATABASE_URL = os.environ.get('DATABASE_URL')
 
@@ -270,6 +270,9 @@ class Database(object):
         """Get a connection to this Database. Connections are retrieved from a
         pool.
         """
+        if not self.open:
+            raise exc.ResourceClosedError('Database closed.')
+
         return Connection(self._engine.connect())
 
     def query(self, query, fetchall=False, **params):

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,29 +1,60 @@
+import pytest
+
 import records
 
 db = records.Database('sqlite:///:memory:')
 
-db.query('CREATE TABLE foo (a integer)')
 
-def test_failing_transaction():
-    tx = db.transaction()
+@pytest.fixture
+def table_setup(request):
+    db.query('CREATE TABLE foo (a integer)')
+    def drop_table():
+        db.query('DROP TABLE foo')
+    request.addfinalizer(drop_table)
+
+
+def test_failing_transaction_self_managed(table_setup):
+    conn = db.get_connection()
+    tx = conn.transaction()
     try:
-        db.query('INSERT INTO foo VALUES (42)')
-        db.query('INSERT INTO foo VALUES (43)')
+        conn.query('INSERT INTO foo VALUES (42)')
+        conn.query('INSERT INTO foo VALUES (43)')
         raise ValueError()
         tx.commit()
-        db.query('INSERT INTO foo VALUES (44)')
+        conn.query('INSERT INTO foo VALUES (44)')
     except:
         tx.rollback()
     finally:
+        conn.close()
         assert db.query('SELECT count(*) AS n FROM foo')[0].n == 0
 
-def test_passing_transaction():
-    tx = db.transaction()
+
+def test_failing_transaction(table_setup):
+    with db.transaction() as conn:
+        conn.query('INSERT INTO foo VALUES (42)')
+        conn.query('INSERT INTO foo VALUES (43)')
+        raise ValueError()
+
+    assert db.query('SELECT count(*) AS n FROM foo')[0].n == 0
+
+
+def test_passing_transaction_self_managed(table_setup):
+    conn = db.get_connection()
+    tx = conn.transaction()
     try:
-        db.query('INSERT INTO foo VALUES (42)')
-        db.query('INSERT INTO foo VALUES (43)')
+        conn.query('INSERT INTO foo VALUES (42)')
+        conn.query('INSERT INTO foo VALUES (43)')
         tx.commit()
     except:
         tx.rollback()
     finally:
+        conn.close()
         assert db.query('SELECT count(*) AS n FROM foo')[0].n == 2
+
+
+def test_passing_transaction(table_setup):
+    with db.transaction() as conn:
+        conn.query('INSERT INTO foo VALUES (42)')
+        conn.query('INSERT INTO foo VALUES (43)')
+
+    assert db.query('SELECT count(*) AS n FROM foo')[0].n == 2


### PR DESCRIPTION
Based on discussion in PR https://github.com/kennethreitz/records/pull/98 and Issue https://github.com/kennethreitz/records/issues/67 it seems that records isn't currently managing SQLAlchemy connection pools properly. This is my quick stab at fixing it.

Essentially, I added a new `Connection` class that must be passed an SQLAlchemy Connection from a pool. This connection is used to make queries to a DB. All of the logic that used to be in `Database` is in this new class, and query methods from `Database` wrap their equivalent `Connection` methods in addition to ensuring that the `Connection` they use is closed when done.

**NOTE: This does have a backwards-incompatible API change.** `Database.transaction` no longer returns a Transaction object, and is instead a context manager that lets the user operate on a single `Connection` during a Transaction. `Connection.transaction` recreates the old behavior. Essentially this maps to how SQLAlchemy lets users deal with transactions (see [here](http://docs.sqlalchemy.org/en/latest/core/connections.html#using-transactions)).

This may need some tweaks, but I wanted to get this out there and get some feedback since I'd personally find it helpful. Thanks!