### PR TITLE
tests/test_transactions.py refactored

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+"""Shared pytest fixtures.
+
+"""
+import pytest
+
+import records
+
+
+@pytest.fixture(params=[
+    # request: (sql_url_id, sql_url_template)
+
+    ('sqlite_memory', 'sqlite:///:memory:'),
+    ('sqlite_file', 'sqlite:///{dbfile}'),
+    # ('psql', 'postgresql://records:records@localhost/records')
+],
+    ids=lambda r: r[0])
+def db(request, tmpdir):
+    """Instance of `records.Database(dburl)`
+
+    Ensure, it gets closed after being used in a test or fixture.
+
+    Parametrized with (sql_url_id, sql_url_template) tuple.
+    If `sql_url_template` contains `{dbfile}` it is replaced with path to a
+    temporary file.
+
+    Feel free to parametrize for other databases and experiment with them.
+    """
+    id, url = request.param
+    # replace {dbfile} in url with temporary db file path
+    url = url.format(dbfile=str(tmpdir / "db.sqlite"))
+    db = records.Database(url)
+    yield db  # providing fixture value for a test case
+    # tear_down
+    db.close()
+
+
+@pytest.fixture
+def foo_table(db):
+    """Database with table `foo` created
+
+    tear_down drops the table.
+
+    Typically applied by `@pytest.mark.usefixtures('foo_table')`
+    """
+    db.query('CREATE TABLE foo (a integer)')
+    yield
+    db.query('DROP TABLE foo')

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,11 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py33, py34, py35, py36
+envlist = py27, py34, py35, py36
 
 [testenv]
 commands =
     pytest tests
 deps =
     pytest
-
+    # psycopg2-binary


### PR DESCRIPTION
Refactored tests for queries in different transaction scenarios.

Tests parametrized to allow testing against different database endpoints, currently to sqlite in memory and sqlite in a file.

Test against postgresql table is commented out (in the test file and in tox.ini as dependency).

Some tests are failing and this is not consistent across backends.