### PR TITLE
Require tablib>=0.11.4 to resolve #52

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ class PublishCommand(Command):
 requires = ['SQLAlchemy;python_version>="3.0"',
             'SQLAlchemy<1.1;python_version<"3.0"',
             'openpyxl<2.5.0', # temporary fix to issue #142
-            'tablib',
+            'tablib>=0.11.4',
             'docopt']
 version = '0.5.3'
 


### PR DESCRIPTION
Given tablib version removed omnijson and uses stdlib one.