### PR TITLE
Removed dependency on old SQLAlchemy (for Python 2.6)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,7 @@ class PublishCommand(Command):
 
         sys.exit()
 
-requires = ['SQLAlchemy;python_version>="3.0"',
-            'SQLAlchemy<1.1;python_version<"3.0"',
+requires = ['SQLAlchemy',
             'openpyxl<2.5.0', # temporary fix to issue #142
             'tablib>=0.11.4',
             'docopt']


### PR DESCRIPTION
The conditional dependency on SQLAlchemy is no longer required since
support for Python 2.6 was removed.