### PR TITLE
Pass kwargs to get_table_names function

### DIFF
--- a/records.py
+++ b/records.py
@@ -276,11 +276,11 @@ class Database(object):
     def __repr__(self):
         return '<Database open={}>'.format(self.open)
 
-    def get_table_names(self, internal=False):
+    def get_table_names(self, internal=False, **kwargs):
         """Returns a list of table names for the connected database."""
 
         # Setup SQLAlchemy for Database inspection.
-        return inspect(self._engine).get_table_names()
+        return inspect(self._engine).get_table_names(**kwargs)
 
     def get_connection(self):
         """Get a connection to this Database. Connections are retrieved from a


### PR DESCRIPTION
When using the `get_table_names` function, the function currently will not allow the user to pass in the `schema` argument. This means that, for instance, you can't get the table names for a PostgreSQL schema other than the default schema. This feature could be added quite easily.