### PR TITLE
remove temporary openpyxl fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ class PublishCommand(Command):
 
 requires = ['SQLAlchemy;python_version>="3.0"',
             'SQLAlchemy<1.1;python_version<"3.0"',
-            'openpyxl<2.5.0', # temporary fix to issue #142
             'tablib>=0.11.4',
             'docopt']
 version = '0.5.3'

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ class PublishCommand(Command):
 requires = ['SQLAlchemy;python_version>="3.0"',
             'SQLAlchemy<1.1;python_version<"3.0"',
             'tablib>=0.11.4',
+            'openpyxl>2.6.0',  # https://github.com/kennethreitz-archive/records/pull/184#issuecomment-606207851
             'docopt']
 version = '0.5.3'
 


### PR DESCRIPTION
The openpyxl dependency doesn't have to be < 2.5 anymore since the [issue in tablib that required this](https://github.com/vinayak-mehta/tablib/issues/324) is fixed.\
Also, openpyxl < 2.5 has some buggy version check that fails when deployed in AWS Lambda, thus making records not useable in this environment.
