### PR TITLE
removed a manual indexer iterator pitfall

### DIFF
--- a/records.py
+++ b/records.py
@@ -424,9 +424,9 @@ def _reduce_datetimes(row):
 
     row = list(row)
 
-    for i in range(len(row)):
-        if hasattr(row[i], 'isoformat'):
-            row[i] = row[i].isoformat()
+    for i, element in enumerate(row):
+        if hasattr(element, 'isoformat'):
+            row[i] = element.isoformat()
     return tuple(row)
 
 def cli():


### PR DESCRIPTION
**The problem**
The code was iterating on the list 'outputs' manually using
for i, element in enumerate(outputs
```python
for i in range(len(row))
```


and accessing the data manually as:
```python
row[i]
```
but Python has a built-in manner to deal with it using the method enumerate



```python
for index, element in enumerate(row):
```
and thus making the access to the data easier

**The solution**
Changed the manual indexer to the enumerated iterator.