### PR TITLE
Fixed query execute & result for Sqlachemy 2.0

### DIFF
--- a/records.py
+++ b/records.py
@@ -357,7 +357,7 @@ class Connection(object):
         """
 
         # Execute the given query.
-        cursor = self._conn.execute(text(query), **params) # TODO: PARAMS GO HERE
+        cursor = self._conn.execute(text(query).bindparams(**params)) # TODO: PARAMS GO HERE
 
         # Row-by-row Record generator.
         row_gen = (Record(cursor.keys(), row) for row in cursor)

--- a/records.py
+++ b/records.py
@@ -50,9 +50,12 @@ class Record(object):
             return self.values()[key]
 
         # Support for string-based lookup.
-        if key in self.keys():
-            i = self.keys().index(key)
-            if self.keys().count(key) > 1:
+        usekeys = self.keys()
+        if hasattr(usekeys, "_keys"): # sqlalchemy 2.x uses (result.RMKeyView which has wrapped _keys as list)
+            usekeys = usekeys._keys
+        if key in usekeys:
+            i = usekeys.index(key)
+            if usekeys.count(key) > 1:
                 raise KeyError("Record contains multiple '{}' fields.".format(key))
             return self.values()[i]
 


### PR DESCRIPTION
Sqlachemy 2.x expects parameters be bound to statement (=text(query))
Also keys lookup in result need to use wrapped _keys instead.