### PR TITLE
Tablib sql export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ with open('report.xls', 'wb') as f:
 0    model-t    True Henry Ford model-t@gmail.com 2016-02-06 22:28:23.894202
 ```
 
+**SQL**
+
+``` python
+>>> rows.export('sql')
+INSERT INTO active_users (username,active,name,user_email,timezone) VALUES ('model-t', TRUE, 'Henry Ford', 'model-t@gmail.com', TIMESTAMP '2016-02-06 22:28:23.894202');
+```
+
 You get the point. All other features of Tablib are also available, so
 you can sort results, add/remove columns/rows, remove duplicates,
 transpose the table, add separators, slice data by column, and more.

--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,13 @@ Excellent for sharing data with friends, or generating reports.
         username  active       name        user_email                   timezone
     0    model-t    True Henry Ford model-t@gmail.com 2016-02-06 22:28:23.894202
 
+**SQL**
+
+.. code:: python
+
+    >>> rows.export('sql')
+    INSERT INTO active_users (username,active,name,user_email,timezone) VALUES ('model-t', TRUE, 'Henry Ford', 'model-t@gmail.com', TIMESTAMP '2016-02-06 22:28:23.894202');
+
 You get the point. All other features of Tablib are also available,
 so you can sort results, add/remove columns/rows, remove duplicates,
 transpose the table, add separators, slice data by column, and more.

--- a/records.py
+++ b/records.py
@@ -99,8 +99,18 @@ class Record(object):
 
         return data
 
+    @property
+    def _typed_dataset(self):
+        """A Tablib Dataset containing the row with original types."""
+        data = tablib.Dataset()
+        data.headers = self.keys()
+        data.append(self.values())
+        return data
+
     def export(self, format, **kwargs):
         """Exports the row to the given format."""
+        if format == 'sql':
+            return self._typed_dataset.export(format, **kwargs)
         return self.dataset.export(format, **kwargs)
 
 
@@ -167,10 +177,6 @@ class RecordCollection(object):
     def __len__(self):
         return len(self._all_rows)
 
-    def export(self, format, **kwargs):
-        """Export the RecordCollection to a given format (courtesy of Tablib)."""
-        return self.dataset.export(format, **kwargs)
-
     @property
     def dataset(self):
         """A Tablib Dataset representation of the RecordCollection."""
@@ -191,6 +197,32 @@ class RecordCollection(object):
             data.append(row)
 
         return data
+
+    @property
+    def _typed_dataset(self):
+        """A Tablib Dataset representation of the RecordCollection with original types."""
+        # Create a new Tablib Dataset.
+        data = tablib.Dataset()
+
+        # If the RecordCollection is empty, just return the empty set
+        # Check number of rows by typecasting to list
+        if len(list(self)) == 0:
+            return data
+
+        # Set the column names as headers on Tablib Dataset.
+        first = self[0]
+
+        data.headers = first.keys()
+        for row in self.all():
+            data.append(row.values())
+
+        return data
+
+    def export(self, format, **kwargs):
+        """Export the RecordCollection to a given format (courtesy of Tablib)."""
+        if format == 'sql':
+            return self._typed_dataset.export(format, **kwargs)
+        return self.dataset.export(format, **kwargs)
 
     def all(self, as_dict=False, as_ordereddict=False):
         """Returns a list of all rows for the RecordCollection. If they haven't


### PR DESCRIPTION
Hi this change is to skip converting datetimes to string when the export type is sql. Have left below dataset property unchanged incase there are people who directly reference it.

@property
    def dataset(self):
        """A Tablib Dataset containing the row."""
        data = tablib.Dataset()
        data.headers = self.keys()

        row = _reduce_datetimes(self.values())
        data.append(row)

        return data

Related to PR:
https://github.com/jazzband/tablib/pull/619

Without the update datetimes are converted as strings:
>>> rows.export('sql')
INSERT INTO active_users (username,active,name,user_email,timezone) VALUES ('model-t', TRUE, 'Henry Ford', 'model-t@gmail.com', '2016-02-06 22:28:23.894202');
```

With the update datetimes are converted properly as timestamps
>>> rows.export('sql')
INSERT INTO active_users (username,active,name,user_email,timezone) VALUES ('model-t', TRUE, 'Henry Ford', 'model-t@gmail.com', TIMESTAMP '2016-02-06 22:28:23.894202');
```

