### PR TITLE
Fix bare except clause in records.py

### DIFF
--- a/records.py
+++ b/records.py
@@ -341,7 +341,7 @@ class Database(object):
         try:
             yield conn
             tx.commit()
-        except:
+        except Exception:
             tx.rollback()
         finally:
             conn.close()


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in the database transaction context manager in `records.py` (line 344).

Bare `except:` catches `BaseException` including `SystemExit` and `KeyboardInterrupt`, which is almost never intentional. Using `except Exception:` restricts catching to regular application exceptions while allowing system-exit signals to propagate normally.